### PR TITLE
Added a flag to control header decoupled test.

### DIFF
--- a/src/ArduinoDUE/Repetier/Communication.cpp
+++ b/src/ArduinoDUE/Repetier/Communication.cpp
@@ -392,8 +392,10 @@ FSTRINGVALUE(Com::tDirectoryCreated,"Directory created")
 FSTRINGVALUE(Com::tCreationFailed,"Creation failed")
 FSTRINGVALUE(Com::tSDErrorCode,"SD errorCode:")
 #endif // SDSUPPORT
+#if DECOUPLING_TEST_ENABLED
 FSTRINGVALUE(Com::tHeaterDecoupled,"Heater decoupled")
 FSTRINGVALUE(Com::tHeaterDecoupledWarning,"One heater seems decoupled from thermistor - disabling all for safety!")
+#endif
 
 void Com::printWarningF(FSTRINGPARAM(text)) {
     printF(tWarning);

--- a/src/ArduinoDUE/Repetier/Communication.h
+++ b/src/ArduinoDUE/Repetier/Communication.h
@@ -377,8 +377,10 @@ FSTRINGVAR(tDirectoryCreated)
 FSTRINGVAR(tCreationFailed)
 FSTRINGVAR(tSDErrorCode)
 #endif // SDSUPPORT
+#if DECOUPLING_TEST_ENABLED
 FSTRINGVAR(tHeaterDecoupled)
 FSTRINGVAR(tHeaterDecoupledWarning)
+#endif
 
 
 static void printNumber(uint32_t n);

--- a/src/ArduinoDUE/Repetier/Configuration.h
+++ b/src/ArduinoDUE/Repetier/Configuration.h
@@ -213,6 +213,8 @@ Overridden if EEPROM activated.*/
 // then you have 3 seconds of increased heating to reach 1°„C.
 #define DECOUPLING_TEST_MIN_TEMP_RISE 1
 
+#define DECOUPLING_TEST_ENABLED true
+
 // for each extruder, fan will stay on until extruder temperature is below this value
 #define EXTRUDER_FAN_COOL_TEMP 50
 // Retraction for sd pause over lcd

--- a/src/ArduinoDUE/Repetier/Configuration.h
+++ b/src/ArduinoDUE/Repetier/Configuration.h
@@ -199,6 +199,9 @@ Overridden if EEPROM activated.*/
 #define PDM_FOR_COOLER 1
 #endif
 
+#define DECOUPLING_TEST_ENABLED true
+
+#if DECOUPLING_TEST_ENABLED
 // The firmware checks if the heater and sensor got decoupled, which is dangerous. SInce it will never reach target
 // temperature, the heater will stay on for every which can burn your printe ror house.
 // As an additional barrier to your smoke detectors (I hope you have one above your printer) we now
@@ -212,8 +215,7 @@ Overridden if EEPROM activated.*/
 // because at startup you already need 7 seconds until heater starts to rise temp. for sensor
 // then you have 3 seconds of increased heating to reach 1°„C.
 #define DECOUPLING_TEST_MIN_TEMP_RISE 1
-
-#define DECOUPLING_TEST_ENABLED true
+#endif
 
 // for each extruder, fan will stay on until extruder temperature is below this value
 #define EXTRUDER_FAN_COOL_TEMP 50
@@ -344,8 +346,10 @@ The codes are only executed for multiple extruder when changing the extruder. */
 #endif
 /** PWM speed for the cooler fan. 0=off 255=full speed */
 #define EXT0_EXTRUDER_COOLER_SPEED 255
+#if DECOUPLING_TEST_ENABLED
 /** Time in ms between a heater action and test of success. Must be more then time between turning heater on and first temp. rise! */
 #define EXT0_DECOUPLE_TEST_PERIOD 30000
+#endif
 
 
 // =========================== Configuration for second extruder ========================
@@ -460,8 +464,10 @@ cog. Direct drive extruder need 0. */
 
 /** PWM speed for the cooler fan. 0=off 255=full speed */
 #define EXT1_EXTRUDER_COOLER_SPEED 255
+#if DECOUPLING_TEST_ENABLED
 /** Time in ms between a heater action and test of success. Must be more then time between turning heater on and first temp. rise! */
 #define EXT1_DECOUPLE_TEST_PERIOD 30000
+#endif
 
 /** If enabled you can select the distance your filament gets retracted during a
 M140 command, after a given temperature is reached. */
@@ -666,9 +672,11 @@ A good start is 30 lower then the optimal value. You need to leave room for cool
 #define HEATED_BED_PID_DGAIN 290
 // maximum time the heater can be switched on. Max = 255.  Overridden if EEPROM activated.
 #define HEATED_BED_PID_MAX 255
+#if DECOUPLING_TEST_ENABLED
 // Time to see a temp. change when fully heating. Consider that beds at higher temp. need longer to rise and cold
 // beds need some time to get the temp. to the sensor. Time is in milliseconds!
 #define HEATED_BED_DECOUPLE_TEST_PERIOD 300000
+#endif
 
 // When temperature exceeds max temp, your heater will be switched off.
 // This feature exists to protect your hotend from overheating accidentally, but *NOT* from thermistor short/failure!

--- a/src/ArduinoDUE/Repetier/Extruder.cpp
+++ b/src/ArduinoDUE/Repetier/Extruder.cpp
@@ -155,7 +155,7 @@ void Extruder::manageTemperatures()
 
         // Run test if heater and sensor are decoupled
         bool decoupleTestRequired = (time - act->lastDecoupleTest) > act->decoupleTestPeriod; // time enough for temperature change?
-        if(decoupleTestRequired && act->isDecoupleFullOrHold() && Printer::isPowerOn()) // Only test when powered
+        if(decoupleTestRequired && act->isDecoupleFullOrHold() && Printer::isPowerOn() && DECOUPLING_TEST_ENABLED) // Only test when powered
         {
             if(act->isDecoupleFull())
             {

--- a/src/ArduinoDUE/Repetier/Extruder.cpp
+++ b/src/ArduinoDUE/Repetier/Extruder.cpp
@@ -78,9 +78,7 @@ void Extruder::manageTemperatures()
     HAL::pingWatchdog();
 #endif // FEATURE_WATCHDOG
     uint8_t errorDetected = 0;
-#if DECOUPLING_TEST_ENABLED
     millis_t time = HAL::timeInMilliseconds(); // compare time for decouple tests
-#endif
     for(uint8_t controller = 0; controller < NUM_TEMPERATURE_LOOPS; controller++)
     {
         if(controller == autotuneIndex) continue;
@@ -1513,7 +1511,9 @@ Extruder extruder[NUM_EXTRUDER] =
 #if TEMP_PID
             ,0,EXT0_PID_INTEGRAL_DRIVE_MAX,EXT0_PID_INTEGRAL_DRIVE_MIN,EXT0_PID_PGAIN_OR_DEAD_TIME,EXT0_PID_I,EXT0_PID_D,EXT0_PID_MAX,0,0,0,{0,0,0,0}
 #endif
+#if DECOUPLING_TEST_ENABLED
             ,0,0,0,EXT0_DECOUPLE_TEST_PERIOD
+#endif
         }
         ,ext0_select_cmd,ext0_deselect_cmd,EXT0_EXTRUDER_COOLER_SPEED,0
     }
@@ -1537,7 +1537,9 @@ Extruder extruder[NUM_EXTRUDER] =
 #if TEMP_PID
             ,0,EXT1_PID_INTEGRAL_DRIVE_MAX,EXT1_PID_INTEGRAL_DRIVE_MIN,EXT1_PID_PGAIN_OR_DEAD_TIME,EXT1_PID_I,EXT1_PID_D,EXT1_PID_MAX,0,0,0,{0,0,0,0}
 #endif
+#if DECOUPLING_TEST_ENABLED
             ,0,0,0,EXT1_DECOUPLE_TEST_PERIOD
+#endif
         }
         ,ext1_select_cmd,ext1_deselect_cmd,EXT1_EXTRUDER_COOLER_SPEED,0
     }
@@ -1561,7 +1563,9 @@ Extruder extruder[NUM_EXTRUDER] =
 #if TEMP_PID
             ,0,EXT2_PID_INTEGRAL_DRIVE_MAX,EXT2_PID_INTEGRAL_DRIVE_MIN,EXT2_PID_PGAIN_OR_DEAD_TIME,EXT2_PID_I,EXT2_PID_D,EXT2_PID_MAX,0,0,0,{0,0,0,0}
 #endif
+#if DECOUPLING_TEST_ENABLED
             ,0,0,0,EXT2_DECOUPLE_TEST_PERIOD
+#endif
         }
         ,ext2_select_cmd,ext2_deselect_cmd,EXT2_EXTRUDER_COOLER_SPEED,0
     }
@@ -1585,7 +1589,9 @@ Extruder extruder[NUM_EXTRUDER] =
 #if TEMP_PID
             ,0,EXT3_PID_INTEGRAL_DRIVE_MAX,EXT3_PID_INTEGRAL_DRIVE_MIN,EXT3_PID_PGAIN_OR_DEAD_TIME,EXT3_PID_I,EXT3_PID_D,EXT3_PID_MAX,0,0,0,{0,0,0,0}
 #endif
+#if DECOUPLING_TEST_ENABLED
             ,0,0,0,EXT3_DECOUPLE_TEST_PERIOD
+#endif
         }
         ,ext3_select_cmd,ext3_deselect_cmd,EXT3_EXTRUDER_COOLER_SPEED,0
     }
@@ -1609,7 +1615,9 @@ Extruder extruder[NUM_EXTRUDER] =
 #if TEMP_PID
             ,0,EXT4_PID_INTEGRAL_DRIVE_MAX,EXT4_PID_INTEGRAL_DRIVE_MIN,EXT4_PID_PGAIN_OR_DEAD_TIME,EXT4_PID_I,EXT4_PID_D,EXT4_PID_MAX,0,0,0,{0,0,0,0}
 #endif
+#if DECOUPLING_TEST_ENABLED
             ,0,0,0,EXT4_DECOUPLE_TEST_PERIOD
+#endif
         }
         ,ext4_select_cmd,ext4_deselect_cmd,EXT4_EXTRUDER_COOLER_SPEED,0
     }
@@ -1633,7 +1641,9 @@ Extruder extruder[NUM_EXTRUDER] =
 #if TEMP_PID
             ,0,EXT5_PID_INTEGRAL_DRIVE_MAX,EXT5_PID_INTEGRAL_DRIVE_MIN,EXT5_PID_PGAIN_OR_DEAD_TIME,EXT5_PID_I,EXT5_PID_D,EXT5_PID_MAX,0,0,0,{0,0,0,0}
 #endif
+#if DECOUPLING_TEST_ENABLED
             ,0,0,0,EXT5_DECOUPLE_TEST_PERIOD
+#endif
         }
         ,ext5_select_cmd,ext5_deselect_cmd,EXT5_EXTRUDER_COOLER_SPEED,0
     }
@@ -1646,7 +1656,9 @@ TemperatureController heatedBedController = {NUM_EXTRUDER,HEATED_BED_SENSOR_TYPE
 #if TEMP_PID
         ,0,HEATED_BED_PID_INTEGRAL_DRIVE_MAX,HEATED_BED_PID_INTEGRAL_DRIVE_MIN,HEATED_BED_PID_PGAIN_OR_DEAD_TIME,HEATED_BED_PID_IGAIN,HEATED_BED_PID_DGAIN,HEATED_BED_PID_MAX,0,0,0,{0,0,0,0}
 #endif
+#if DECOUPLING_TEST_ENABLED
         ,0,0,0,HEATED_BED_DECOUPLE_TEST_PERIOD
+#endif
                                             };
 #else
 #define NUM_TEMPERATURE_LOOPS NUM_EXTRUDER

--- a/src/ArduinoDUE/Repetier/Extruder.h
+++ b/src/ArduinoDUE/Repetier/Extruder.h
@@ -18,8 +18,10 @@ extern uint8_t manageMonitor;
 #define HTR_DEADTIME 3
 
 #define TEMPERATURE_CONTROLLER_FLAG_ALARM 1
+#if DECOUPLING_TEST_ENABLED
 #define TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_FULL 2 //< Full heating enabled
 #define TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_HOLD 4  //< Holding target temperature
+#endif
 
 /** TemperatureController manages one heater-temperature sensore loop. You can have up to
 4 loops allowing pid/bang bang for up to 3 extruder and the heated bed.
@@ -53,16 +55,18 @@ class TemperatureController
     float tempArray[4];
 #endif
     uint8_t flags;
+#if DECOUPLING_TEST_ENABLED
     millis_t lastDecoupleTest;  ///< Last time of decoupling sensor-heater test
     float  lastDecoupleTemp;  ///< Temperature on last test
     millis_t decoupleTestPeriod; ///< Time between setting and testing decoupling.
-
+#endif
 
     void setTargetTemperature(float target);
     void updateCurrentTemperature();
     void updateTempControlVars();
     inline bool isAlarm() {return flags & TEMPERATURE_CONTROLLER_FLAG_ALARM;}
     inline void setAlarm(bool on) {if(on) flags |= TEMPERATURE_CONTROLLER_FLAG_ALARM; else flags &= ~TEMPERATURE_CONTROLLER_FLAG_ALARM;}
+#if DECOUPLING_TEST_ENABLED
     inline bool isDecoupleFull() {return flags & TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_FULL;}
     inline bool isDecoupleFullOrHold() {return flags & (TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_FULL | TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_HOLD);}
     inline void setDecoupleFull(bool on) {flags &= ~(TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_FULL | TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_HOLD); if(on) flags |= TEMPERATURE_CONTROLLER_FLAG_DECOUPLE_FULL;}
@@ -84,6 +88,8 @@ class TemperatureController
     inline void stopDecouple() {
         setDecoupleFull(false);
     }
+#endif
+
 #if TEMP_PID
     void autotunePID(float temp,uint8_t controllerId,bool storeResult);
 #endif


### PR DESCRIPTION
I added a flag called DECOUPLING_TEST_ENABLED in Configuration.h that controls whether or not the decoupling test runs. The default setting is ‘true’, but it is now easy to disable the test by just changing this value to ‘false’ instead of messing with the timing settings.