### PR TITLE
Modified extruder naming

### DIFF
--- a/src/ArduinoDUE/Repetier/Printer.cpp
+++ b/src/ArduinoDUE/Repetier/Printer.cpp
@@ -231,7 +231,7 @@ void Printer::cleanNozzle(bool restoreposition, int8_t extT)
 	moveToReal(xMin,yMin+CLEAN_Y+2,IGNORE_COORDINATE,IGNORE_COORDINATE,homingFeedrate[0]);
 	#endif
 	#if DAVINCI ==2 || DAVINCI ==3
-		if(extT == 0 || extT == -1)
+		if(extT == 1 || extT == -1)
 		{
 			//first step
 			moveToReal(xMin + CLEAN_X-ENDSTOP_X_BACK_ON_HOME,yMin + CLEAN_Y-ENDSTOP_Y_BACK_ON_HOME,IGNORE_COORDINATE,IGNORE_COORDINATE,homingFeedrate[0]);
@@ -244,7 +244,7 @@ void Printer::cleanNozzle(bool restoreposition, int8_t extT)
 			//move out to be sure first drop go to purge box
 			Commands::waitUntilEndOfAllMoves();
 		}
-		if(extT == 1 || extT == -1)
+		if(extT == 0 || extT == -1)
 		{
 		        moveToReal(xLength,yMin+10,IGNORE_COORDINATE,IGNORE_COORDINATE,homingFeedrate[0]);
 		        moveToReal(IGNORE_COORDINATE,yMin-ENDSTOP_Y_BACK_ON_HOME,IGNORE_COORDINATE,IGNORE_COORDINATE,homingFeedrate[0]);

--- a/src/ArduinoDUE/Repetier/uilang.h
+++ b/src/ArduinoDUE/Repetier/uilang.h
@@ -241,19 +241,23 @@
 #if NUM_EXTRUDER == 1
 #define UI_TEXT_EXTR0_TEMP       "Extrud.:  %E0" cDEG "C"
 #else
-#define UI_TEXT_EXTR0_TEMP       "Extrud. 1:%E0" cDEG "C"
+#define UI_TEXT_EXTR0_TEMP       "Left Ext: %E0" cDEG "C"
 #endif
-#define UI_TEXT_EXTR1_TEMP       "Extrud. 2:%E1" cDEG "C"
+#define UI_TEXT_EXTR1_TEMP       "Right Ext:%E1" cDEG "C"
 #define UI_TEXT_EXTR2_TEMP       "Extrud. 3:%E2" cDEG "C"
 #if NUM_EXTRUDER == 1
 #define UI_TEXT_EXTR0_OFF        "SwitchOff Ext %B4"
 #else
-#define UI_TEXT_EXTR0_OFF        "SwitchOff Ext1%B4"
+#define UI_TEXT_EXTR0_OFF        "Disable Left  %B4"
 #endif
-#define UI_TEXT_EXTR1_OFF        "SwitchOff Ext2%B5"
+#define UI_TEXT_EXTR1_OFF        "Disable Right %B5"
 #define UI_TEXT_EXTR2_OFF        "SwitchOff Ext3%B6"
+#if NUM_EXTRUDER == 1
 #define UI_TEXT_EXTR0_SELECT     "%X0Select Extr.1"
-#define UI_TEXT_EXTR1_SELECT     "%X1Select Extr.2"
+#else
+#define UI_TEXT_EXTR0_SELECT     "%X0Select Left"
+#endif
+#define UI_TEXT_EXTR1_SELECT     "%X1Select Right"
 #define UI_TEXT_EXTR2_SELECT     "%X2Select Extr.3"
 #define UI_TEXT_EXTR_ORIGIN      "Set Origin"
 #define UI_TEXT_PRINT_X          "Print X:%ax"

--- a/src/ArduinoDUE/Repetier/uimenu.h
+++ b/src/ArduinoDUE/Repetier/uimenu.h
@@ -1135,14 +1135,14 @@ UI_MENU_ACTIONCOMMAND(ui_menu_ext_off0,UI_TEXT_EXTR0_OFF,UI_ACTION_EXTRUDER0_OFF
 UI_MENU_ACTIONCOMMAND(ui_menu_ext_off1,UI_TEXT_EXTR1_OFF,UI_ACTION_EXTRUDER1_OFF, ADVANCED_MODE)
 //UI_MENU_ACTIONCOMMAND(ui_menu_ext_origin,UI_TEXT_EXTR_ORIGIN,UI_ACTION_RESET_EXTRUDER, ADVANCED_MODE)
 #if NUM_EXTRUDER == 2
-#define UI_MENU_EXTCOND &ui_menu_ext_temp0,&ui_menu_ext_temp1,&ui_menu_ext_off0,&ui_menu_ext_off1,&ui_menu_ext_sel0,&ui_menu_ext_sel1,
-#define UI_MENU_EXTCNT 6
+#define UI_MENU_EXTCOND &ui_menu_ext_temp0,&ui_menu_ext_temp1,&ui_menu_ext_off0,&ui_menu_ext_off1,
+#define UI_MENU_EXTCNT 4
 #elif NUM_EXTRUDER>2
 UI_MENU_CHANGEACTION(ui_menu_ext_temp2,UI_TEXT_EXTR2_TEMP,UI_ACTION_EXTRUDER2_TEMP, ADVANCED_MODE)
 UI_MENU_ACTIONCOMMAND(ui_menu_ext_sel2,UI_TEXT_EXTR2_SELECT,UI_ACTION_SELECT_EXTRUDER2, ADVANCED_MODE)
 UI_MENU_ACTIONCOMMAND(ui_menu_ext_off2,UI_TEXT_EXTR2_OFF,UI_ACTION_EXTRUDER2_OFF, ADVANCED_MODE)
-#define UI_MENU_EXTCOND &ui_menu_ext_temp0,&ui_menu_ext_temp1,&ui_menu_ext_temp2,&ui_menu_ext_off0,&ui_menu_ext_off1,&ui_menu_ext_off2,&ui_menu_ext_sel0,&ui_menu_ext_sel1,&ui_menu_ext_sel1,
-#define UI_MENU_EXTCNT 9
+#define UI_MENU_EXTCOND &ui_menu_ext_temp0,&ui_menu_ext_temp1,&ui_menu_ext_temp2,&ui_menu_ext_off0,&ui_menu_ext_off1,&ui_menu_ext_off2,
+#define UI_MENU_EXTCNT 6
 #else
 #define UI_MENU_EXTCOND &ui_menu_ext_temp0,&ui_menu_ext_off0,
 #define UI_MENU_EXTCNT 2


### PR DESCRIPTION
Changed extruder naming in heating and selection menus, removed unnecessary prompts from heating menu, and also modified M100 to reflect correct extruders when using T0 and T1.