### PR TITLE
Corrected USBCore.cpp filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The previous version (based on repetier v0.91) can be found [here](https://githu
 1. With the machine off remove the back panel and short the jumper JP1 or J37 depending on model.  Some Boards do not have jumper pins exposed but can still be shorted with a conductive wire.
 2. Turn the machine on and wait a few seconds then turn it off again.  The machine will have been flashed removing the current stock firmware and allowing it to be detected as a normal arduino DUE. NOTE: Windows users may need to install drivers to detect the board.  Consult the Voltivo forums.
 3. Use an arduino IDE supporting arduino DUE, [version 1.5.8+ or  1.6.5](http://arduino.cc/en/Main/OldSoftwareReleases), 1.6.0+ bring several issues, but 1.6.5 seems working well with Due 1.6.4 module for board manager.
-4. Update arduino files (variants.cpp and USBcore.cpp) with the one(s) present in src\ArduinoDUE\AdditionalArduinoFiles\1.5.8. or in src\ArduinoDUE\AdditionalArduinoFiles\1.6.5 according your IDE version   
+4. Update arduino files (variants.cpp and USBCore.cpp) with the one(s) present in src\ArduinoDUE\AdditionalArduinoFiles\1.5.8. or in src\ArduinoDUE\AdditionalArduinoFiles\1.6.5 according your IDE version   
 NOTE: You do not need to compile arduino from source these files are in the arduino directory structure.  On Mac you will need to right click on the Arduino.app to Show Package Contents.    
 5. Open the project file named repetier.ino located in src\ArduinoDUE\Repetier directory in the arduino IDE. 
 6. Modify the DAVINCI define in Configuration.h file to match your targeted Da Vinci.  See below.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can do so by homeing all axis, turning off the printer and manually adjustin
 For information on upgrading from or reverting to stock FW and other procedures please check [Da Vinci Voltivo forum](http://voltivo.com/forum/davinci).    
 <h4>:warning:There is no known way to revert to stock FW on 1.0A/2.0A/AiO until today.</h4>     
 
-Do not forget to modify the configuration.h to match your targeted Da Vinci: 1.0, 2.0 SF or 2.0.   
+Do not forget to modify the Configuration.h to match your targeted Da Vinci: 1.0, 2.0 SF or 2.0.   
 for basic installation just change :   
 '<code>#define DAVINCI 1 // "1" For DAVINCI 1.0, "2" For DAVINCI 2.0 with 1 FAN, "3" For DAVINCI 2.0 with 2 FANS, 4 For AiO （no scanner)</code>'    
   0 for not Davinci board (like DUE/RADDS)    


### PR DESCRIPTION
Change instructions to copy USBCore.cpp instead of USBcore.cpp.  The latter file does not exist.